### PR TITLE
Make it possible to use this image as an executable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.env.test.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - touch .env.test.local
     - echo "DEBRICKED_USERNAME=$username" >> .env.test.local
     - echo "DEBRICKED_PASSWORD=$password" >> .env.test.local
-    - docker build -t php-test .
+    - docker build --target=test -t php-test .
 
 script:
-    - travis_wait 30 docker run php-test --env-file ./.env.test.local
+    - travis_wait 30 docker run --env-file ./.env.test.local php-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.2-cli-alpine
+# common stage
+FROM php:7.2-cli-alpine AS common
 
 RUN apk add bash git zlib-dev libzip-dev
 RUN docker-php-ext-install zip
@@ -9,4 +10,23 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ 
 WORKDIR /
 COPY . /home
 
+# test stage
+FROM scratch AS test
+COPY --from=common / /
+
 ENTRYPOINT /home/ci/test.sh
+
+# cli stage
+FROM scratch AS cli
+COPY --from=common / /
+
+# Create suitable point where we expect dependency files to be mounted.
+RUN mkdir /data
+
+# Run script once to install deps once and for all.
+RUN /home/entrypoint.sh
+
+ENTRYPOINT ["/home/entrypoint.sh"]
+
+# Default is same behaviour as if no arguments are given.
+CMD []

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 
+Copyright (c) 2019, 2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,9 +7,30 @@
 Command Line Tool (CLI) for interacting with [Debricked](https://debricked.com). Supports uploading and checking your dependency files for vulnerabilities.
 
 ## Documentation
-Head over to our [Integration documentation page](https://debricked.com/knowledge-base/articles/integrations/#debricked-cli).
+Head over to our [Integration documentation page](https://debricked.com/knowledge-base/articles/integrations/#debricked-cli) for the main source of documentation.
+
+To run the tool using only Docker, instead of a local install, use it as below,
+where the current directory is assumed to contain the project you wish to scan.
+
+```
+docker run -it --rm -v $PWD:/data:ro debricked/debricked-cli <command>
+```
+
+A practical example of scanning a local repository in your current working directory:
+
+```
+docker run -it --rm -v $PWD:/data:ro debricked/debricked-cli debricked:scan user@example.com password myproject myrelease null cli
+```
 
 ## Code contributions
+
+### Build image for running the tool
+
+To build the cli tool for running
+
+```
+docker build -t debricked/debricked-cli .
+```
 
 ### Run tests
 All contributions are greatly welcome! To help you get started we have a included a

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd /data
+/home/bin/console "$@"

--- a/localTest.sh
+++ b/localTest.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build -t php-test . && docker run php-test --env-file ./.env.test.local
+docker build --target=test -t debricked/debricked-cli-test . && docker run --env-file ./.env.test.local debricked/debricked-cli-test


### PR DESCRIPTION
The tool can then be used without installing php and composer on your machine, only Docker is required. The dependency files can still be accessed by the container using a bind mount.