### PR TITLE
Dont ignore dotfiles when selecting which files to upload to debricked

### DIFF
--- a/src/Command/FindAndUploadFilesCommand.php
+++ b/src/Command/FindAndUploadFilesCommand.php
@@ -213,6 +213,7 @@ class FindAndUploadFilesCommand extends Command
         $searchDirectory = preg_replace('#/+#', '/', $searchDirectory); // remove duplicate slashes.
 
         $finder = new Finder();
+        $finder->ignoreDotFiles(false);
         $finder->files()->in($searchDirectory);
         if (empty($directoriesToExcludeString) === false && \is_array(
                 $directoriesToExcludeArray = \explode(',', $directoriesToExcludeString)


### PR DESCRIPTION
We want to include all files, even ones that start with a dot