### PR TITLE
Make license profile optional

### DIFF
--- a/.github/workflows/test-staging.yml
+++ b/.github/workflows/test-staging.yml
@@ -1,6 +1,6 @@
 name: Test CI pipeline for staging
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test CI pipeline
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   tests:

--- a/src/Command/FindAndUploadFilesCommand.php
+++ b/src/Command/FindAndUploadFilesCommand.php
@@ -258,7 +258,7 @@ class FindAndUploadFilesCommand extends Command
         $uploadedAdjacentFilePaths = [];
         $progressBar = new ProgressBar($output);
         $progressBar->start();
-        $progressBar->setFormat(' %current% file(s) found [%bar%] %percent:3s%% %elapsed:6s% %memory:6s%');
+        $progressBar->setFormat(' %current% file(s) found [%bar%] %percent:3s%% %elapsed:6s%');
         $this->setProgressBarStyle($progressBar);
 
         foreach ($finder as $file) {

--- a/src/Command/LicenseReportCommand.php
+++ b/src/Command/LicenseReportCommand.php
@@ -76,7 +76,7 @@ class LicenseReportCommand extends Command
             )
             ->addArgument(
                 self::ARGUMENT_PROFILE,
-                InputArgument::REQUIRED,
+                InputArgument::OPTIONAL,
                 'The license risk profile you wish to use for this scan: internal, network, distributed, or consumer-electronic',
                 null,
             )
@@ -109,7 +109,10 @@ class LicenseReportCommand extends Command
             \strval($input->getArgument(FindAndUploadFilesCommand::ARGUMENT_PASSWORD))
         );
         $uploadId = \intval($input->getArgument(self::ARGUMENT_UPLOAD_ID));
-        $profile = \strval($input->getArgument(self::ARGUMENT_PROFILE));
+        $profile = $input->getArgument(self::ARGUMENT_PROFILE);
+        if ($profile !== null) {
+            $profile = \strval($profile);
+        }
         $outputFilename = $input->getOption(self::OPTION_OUTPUT_FILE);
         $format = \strval($input->getOption(self::OPTION_FORMAT));
 
@@ -192,12 +195,15 @@ class LicenseReportCommand extends Command
     /**
      * @throws TransportExceptionInterface
      */
-    private function makeRequest(API $api, int $uploadId, string $profile, string $format, bool $snippets): ResponseInterface
+    private function makeRequest(API $api, int $uploadId, ?string $profile, string $format, bool $snippets): ResponseInterface
     {
         $query = [
             'scanId' => $uploadId,
-            'profile' => $profile,
         ];
+
+        if ($profile !== null) {
+            $query = \array_merge($query, ['profile' => $profile]);
+        }
 
         if ($snippets) {
             $query = \array_merge($query, ['snippets' => '1']);


### PR DESCRIPTION
Leaving it out will instead use the one selected in the tool

Also:
* Remove memory (RAM) usage from progress bar, since it is confusing and can be interpreted as "amount of data uploaded" which it isn't.